### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sharfuddin18/Codemaster-Ai/security/code-scanning/3](https://github.com/sharfuddin18/Codemaster-Ai/security/code-scanning/3)

Add an explicit `permissions` block to the workflow, at the root level, with the minimum required scope.  
For this CI workflow (checkout + setup Python + install + lint + test), `contents: read` is sufficient.

Best single fix (no functional change):
- Edit `.github/workflows/python-package.yml`
- Insert a root-level block after the `on:` section (or before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
