### PR TITLE
Phase 4: Local Benchmarking & Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ backend/.env.*
 
 # Ollama runtime state and generated identity
 data/ollama/
+
+# Phase 4 benchmark results
+.codemaster/benchmarks/

--- a/PHASE_4_LOCAL_BENCHMARKING.md
+++ b/PHASE_4_LOCAL_BENCHMARKING.md
@@ -1,0 +1,69 @@
+# Phase 4 — Local Benchmarking & Metrics
+
+Phase 4 adds a controlled benchmark layer for comparing two execution conditions:
+
+1. **Raw Ollama** — the benchmark task is sent to the selected Ollama model without Codemaster repository context.
+2. **Codemaster RAG** — the same task is passed through the existing Phase 3 hybrid retrieval path, the retrieved repository context is assembled into the prompt, and the selected Ollama model is invoked.
+
+The benchmark is a measurement tool, not a claim that RAG is faster or better.
+
+## Metrics
+
+### TTFT — Time To First Token
+
+TTFT is measured from the start of the Ollama HTTP request until the first non-empty streamed response chunk is received. It is **not** the total request latency.
+
+### TPS — Tokens Per Second
+
+TPS uses Ollama's authoritative generation metadata:
+
+`eval_count / (eval_duration_ns / 1,000,000,000)`
+
+If Ollama does not provide valid token/timing metadata, TPS is recorded as unavailable rather than fabricated.
+
+### Context Retrieval Precision
+
+Each benchmark case declares expected repository source files. Precision is calculated deterministically as:
+
+`|expected sources ∩ retrieved sources| / |expected sources|`
+
+This is source-file precision, not a semantic relevance score.
+
+## Benchmark cases
+
+The initial controlled cases target repository-aware tasks covering:
+
+- hybrid dense + BM25 ranking;
+- vector-index failure state;
+- generation/context handoff and retrieval failure behavior;
+- Ollama provider runtime behavior.
+
+The cases and expected source labels live in `benchmarks/phase4_cases.json`.
+
+## Reproducibility
+
+Run from the repository root after installing the existing project dependencies:
+
+```bash
+python run_phase4_benchmark.py
+```
+
+Useful overrides:
+
+```bash
+python run_phase4_benchmark.py --model qwen2.5-coder:1.5b --top-k 3 --alpha 0.5 --min-score 0.0
+```
+
+The runner records model, Ollama endpoint, retrieval configuration, benchmark cases, measurement methodology, environment metadata, per-case outputs, failures, and aggregate metrics. Results are persisted atomically to `.codemaster/benchmarks/phase4-latest.json` by default and should not be committed.
+
+## Live execution and offline behavior
+
+A real benchmark result is produced only when the runner actually receives a live Ollama response. If Ollama is unavailable, the run records a controlled failure and exits non-zero; the implementation does not substitute mock output for live benchmark results.
+
+The Phase 4 unit tests use deterministic fixtures and an intentionally unavailable localhost endpoint to verify infrastructure and failure handling without presenting those executions as live benchmark data.
+
+## Fair-comparison rules
+
+Baseline and RAG use the same benchmark task, model, generation endpoint, timeout, and Ollama generation configuration. The intended experimental difference is the injected repository context. Warm/cold behavior should be interpreted from the recorded run conditions rather than silently mixing runs.
+
+No benchmark number should be published as a performance guarantee. Small samples should be treated as observations, not statistically general performance claims.

--- a/PHASE_4_LOCAL_BENCHMARKING.md
+++ b/PHASE_4_LOCAL_BENCHMARKING.md
@@ -23,11 +23,15 @@ If Ollama does not provide valid token/timing metadata, TPS is recorded as unava
 
 ### Context Retrieval Precision
 
-Each benchmark case declares expected repository source files. Precision is calculated deterministically as:
+Each benchmark case declares expected repository source files. **Context Retrieval Precision measures the fraction of retrieved source entries that are relevant to the expected source set.** It is calculated deterministically as:
 
-`|expected sources ∩ retrieved sources| / |expected sources|`
+`number of relevant retrieved sources / number of retrieved sources`
 
-This is source-file precision, not a semantic relevance score.
+For example, expected `['a.py']` and retrieved `['a.py', 'b.py', 'c.py']` gives `1 / 3 = 0.333333...`.
+
+If no sources are retrieved, precision is `0.0`. If the expected source set is empty, precision is also deliberately defined as `0.0` because there is no positive relevance target.
+
+This is source-file precision, not a semantic relevance score, and it must not be confused with recall of expected sources.
 
 ## Benchmark cases
 

--- a/backend/phase4_benchmark.py
+++ b/backend/phase4_benchmark.py
@@ -1,0 +1,456 @@
+"""Phase 4 controlled local benchmark: Raw Ollama vs Codemaster retrieval + Ollama."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    case_id: str
+    task: str
+    expected_sources: tuple[str, ...]
+
+
+@dataclass
+class InferenceResult:
+    benchmark_case: str
+    execution_mode: str
+    model: str
+    prompt_id: str
+    timestamp: str
+    success: bool
+    ttft_ms: float | None
+    tps: float | None
+    generation_duration_ms: float | None
+    retrieved_sources: list[str] = field(default_factory=list)
+    expected_sources: list[str] = field(default_factory=list)
+    retrieval_precision: float | None = None
+    output: str = ""
+    error: str | None = None
+    environment: dict[str, Any] = field(default_factory=dict)
+    token_count: int | None = None
+    raw_timing: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class BenchmarkRun:
+    schema_version: str
+    run_id: str
+    configuration: dict[str, Any]
+    results: list[InferenceResult]
+    aggregate: dict[str, Any]
+
+
+CASES: tuple[BenchmarkCase, ...] = (
+    BenchmarkCase(
+        "retrieval-hybrid-ranking",
+        (
+            "Explain how Codemaster-AI combines dense vector retrieval and BM25, "
+            "including how the hybrid score is formed."
+        ),
+        ("backend/app/services/hybrid_retriever.py",),
+    ),
+    BenchmarkCase(
+        "vector-index-failure-state",
+        (
+            "Explain how the repository vector engine handles indexing failures and "
+            "what state it exposes after a failed build."
+        ),
+        ("backend/app/utils/vector_engine.py",),
+    ),
+    BenchmarkCase(
+        "generation-context-handoff",
+        (
+            "Explain how the generation route retrieves repository context and passes it "
+            "into the model prompt, including the retrieval failure behavior."
+        ),
+        ("backend/app/routes/generation.py",),
+    ),
+    BenchmarkCase(
+        "ollama-provider-runtime",
+        "Explain how the Ollama provider calls the local API, selects its model, and handles provider failures.",
+        ("backend/app/llm/providers/ollama.py",),
+    ),
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def safe_environment() -> dict[str, Any]:
+    return {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "system": platform.system(),
+        "machine": platform.machine(),
+        "ollama_base_url": os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+    }
+
+
+def retrieval_precision(expected: Sequence[str], retrieved: Sequence[str]) -> float:
+    expected_set = {str(x) for x in expected if str(x)}
+    retrieved_set = {str(x) for x in retrieved if str(x)}
+    if not expected_set:
+        return 0.0
+    return len(expected_set & retrieved_set) / len(expected_set)
+
+
+def _number(value: Any) -> int | float | None:
+    return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def calculate_tps(eval_count: Any, eval_duration_ns: Any) -> float | None:
+    count = _number(eval_count)
+    duration = _number(eval_duration_ns)
+    if count is None or duration is None or count < 0 or duration <= 0:
+        return None
+    return count / (duration / 1_000_000_000)
+
+
+def paired_comparison(results: Iterable[InferenceResult]) -> dict[str, Any]:
+    pairs: dict[str, dict[str, InferenceResult]] = {}
+    for result in results:
+        pairs.setdefault(result.benchmark_case, {})[result.execution_mode] = result
+    comparisons = []
+    for case_id in sorted(pairs):
+        pair = pairs[case_id]
+        baseline = pair.get("raw_ollama")
+        rag = pair.get("codemaster_rag")
+        if baseline is None or rag is None:
+            continue
+        comparisons.append({
+            "benchmark_case": case_id,
+            "baseline_success": baseline.success,
+            "rag_success": rag.success,
+            "ttft_delta_ms_rag_minus_baseline": (
+                rag.ttft_ms - baseline.ttft_ms
+                if rag.ttft_ms is not None and baseline.ttft_ms is not None
+                else None
+            ),
+            "tps_delta_rag_minus_baseline": (
+                rag.tps - baseline.tps
+                if rag.tps is not None and baseline.tps is not None
+                else None
+            ),
+            "retrieval_precision": rag.retrieval_precision,
+        })
+    return {"cases": comparisons, "paired_case_count": len(comparisons)}
+
+
+def aggregate(results: Iterable[InferenceResult]) -> dict[str, Any]:
+    grouped: dict[str, list[InferenceResult]] = {}
+    for result in results:
+        grouped.setdefault(result.execution_mode, []).append(result)
+
+    report: dict[str, Any] = {}
+    for mode, items in grouped.items():
+        ttft = [r.ttft_ms for r in items if r.ttft_ms is not None and r.success]
+        tps = [r.tps for r in items if r.tps is not None and r.success]
+        precision = [r.retrieval_precision for r in items if r.retrieval_precision is not None]
+        report[mode] = {
+            "cases": len(items),
+            "success_rate": sum(r.success for r in items) / len(items) if items else 0.0,
+            "average_ttft_ms": statistics.mean(ttft) if ttft else None,
+            "median_ttft_ms": statistics.median(ttft) if ttft else None,
+            "average_tps": statistics.mean(tps) if tps else None,
+            "median_tps": statistics.median(tps) if tps else None,
+            "average_retrieval_precision": statistics.mean(precision) if precision else None,
+            "median_retrieval_precision": statistics.median(precision) if precision else None,
+        }
+    return report
+
+
+def _post_json_stream(
+    url: str,
+    payload: dict[str, Any],
+    timeout: float,
+    on_first_token: Callable[[], None],
+) -> tuple[str, dict[str, Any], float, float]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    start = time.perf_counter()
+    first_token_time: float | None = None
+    output_parts: list[str] = []
+    final: dict[str, Any] = {}
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            for raw_line in response:
+                if not raw_line.strip():
+                    continue
+                item = json.loads(raw_line.decode("utf-8"))
+                chunk = str(item.get("response", ""))
+                if chunk and first_token_time is None:
+                    first_token_time = time.perf_counter()
+                    on_first_token()
+                output_parts.append(chunk)
+                if item.get("done") is True:
+                    final = item
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Ollama HTTP {exc.code}: {detail}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError(f"Ollama connection failed: {exc}") from exc
+    end = time.perf_counter()
+    if first_token_time is None:
+        raise RuntimeError("Ollama returned no generated token")
+    return "".join(output_parts), final, (first_token_time - start) * 1000, (end - start) * 1000
+
+
+def run_ollama(
+    prompt: str,
+    model: str,
+    base_url: str,
+    timeout: float,
+    case: BenchmarkCase,
+    mode: str,
+    retrieved: list[str],
+) -> InferenceResult:
+    payload = {"model": model, "prompt": prompt, "stream": True}
+    timestamp = utc_now()
+    try:
+        output, metadata, ttft_ms, wall_ms = _post_json_stream(
+            f"{base_url.rstrip('/')}/api/generate", payload, timeout, lambda: None
+        )
+        eval_count = _number(metadata.get("eval_count"))
+        eval_duration = _number(metadata.get("eval_duration"))
+        return InferenceResult(
+            benchmark_case=case.case_id,
+            execution_mode=mode,
+            model=model,
+            prompt_id=case.case_id,
+            timestamp=timestamp,
+            success=bool(output.strip()),
+            ttft_ms=ttft_ms,
+            tps=calculate_tps(eval_count, eval_duration),
+            generation_duration_ms=(eval_duration / 1_000_000) if eval_duration else wall_ms,
+            retrieved_sources=retrieved,
+            expected_sources=list(case.expected_sources),
+            retrieval_precision=(
+                retrieval_precision(case.expected_sources, retrieved)
+                if mode == "codemaster_rag"
+                else None
+            ),
+            output=output,
+            environment=safe_environment(),
+            token_count=eval_count,
+            raw_timing={
+                k: metadata.get(k)
+                for k in (
+                    "total_duration",
+                    "load_duration",
+                    "prompt_eval_count",
+                    "prompt_eval_duration",
+                    "eval_count",
+                    "eval_duration",
+                )
+                if k in metadata
+            },
+        )
+    except Exception as exc:
+        return InferenceResult(
+            benchmark_case=case.case_id,
+            execution_mode=mode,
+            model=model,
+            prompt_id=case.case_id,
+            timestamp=timestamp,
+            success=False,
+            ttft_ms=None,
+            tps=None,
+            generation_duration_ms=None,
+            retrieved_sources=retrieved,
+            expected_sources=list(case.expected_sources),
+            retrieval_precision=(
+                retrieval_precision(case.expected_sources, retrieved)
+                if mode == "codemaster_rag"
+                else None
+            ),
+            environment=safe_environment(),
+            error=str(exc),
+        )
+
+
+def raw_prompt(case: BenchmarkCase) -> str:
+    return (
+        "You are evaluating Codemaster-AI as a coding assistant. "
+        "Answer this repository-specific task without being given repository context:\n\n"
+        f"{case.task}\n"
+    )
+
+
+def rag_prompt(case: BenchmarkCase, context: Sequence[dict[str, Any]]) -> str:
+    formatted = []
+    for index, item in enumerate(context, 1):
+        formatted.append(f"[{index}] File: {item.get('file', 'unknown')}\n{item.get('text', item.get('snippet', ''))}")
+    return (
+        "You are evaluating Codemaster-AI as a project-aware coding assistant. "
+        "Use only the retrieved repository context when answering.\n\n"
+        f"Task:\n{case.task}\n\nRetrieved repository context:\n\n" + "\n\n".join(formatted)
+    )
+
+
+def load_cases(path: Path | None = None) -> list[BenchmarkCase]:
+    if path is None:
+        default_path = Path(__file__).resolve().parents[1] / "benchmarks" / "phase4_cases.json"
+        if default_path.exists():
+            path = default_path
+        else:
+            return list(CASES)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return [
+        BenchmarkCase(
+            str(item["case_id"]),
+            str(item["task"]),
+            tuple(str(source) for source in item.get("expected_sources", [])),
+        )
+        for item in raw
+    ]
+
+
+def retrieve_context(case: BenchmarkCase, top_k: int, alpha: float, min_score: float) -> list[dict[str, Any]]:
+    try:
+        from backend.app.routes.generation import _parse_retrieval_doc, get_hybrid_retriever
+    except Exception as exc:
+        raise RuntimeError(f"Codemaster retrieval could not be imported: {exc}") from exc
+    results = get_hybrid_retriever().search(case.task, top_k=top_k, alpha=alpha, min_score=min_score)
+    return [_parse_retrieval_doc(result) for result in results]
+
+
+def execute(
+    cases: Sequence[BenchmarkCase],
+    model: str,
+    base_url: str,
+    timeout: float,
+    top_k: int,
+    alpha: float,
+    min_score: float,
+) -> BenchmarkRun:
+    results: list[InferenceResult] = []
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    for case in cases:
+        baseline = run_ollama(raw_prompt(case), model, base_url, timeout, case, "raw_ollama", [])
+        results.append(baseline)
+        try:
+            context = retrieve_context(case, top_k, alpha, min_score)
+            retrieved_sources = sorted({str(item.get("file", "unknown")) for item in context if item.get("file")})
+            rag = run_ollama(
+                rag_prompt(case, context),
+                model,
+                base_url,
+                timeout,
+                case,
+                "codemaster_rag",
+                retrieved_sources,
+            )
+        except Exception as exc:
+            rag = InferenceResult(
+                benchmark_case=case.case_id,
+                execution_mode="codemaster_rag",
+                model=model,
+                prompt_id=case.case_id,
+                timestamp=utc_now(),
+                success=False,
+                ttft_ms=None,
+                tps=None,
+                generation_duration_ms=None,
+                expected_sources=list(case.expected_sources),
+                retrieval_precision=0.0,
+                environment=safe_environment(),
+                error=str(exc),
+            )
+        results.append(rag)
+    config = {
+        "model": model,
+        "ollama_base_url": base_url,
+        "timeout_seconds": timeout,
+        "top_k": top_k,
+        "alpha": alpha,
+        "min_score": min_score,
+        "benchmark_cases": [c.case_id for c in cases],
+        "measurement": {
+            "ttft": "wall-clock elapsed from HTTP request start until first non-empty streamed response chunk",
+            "tps": "Ollama eval_count divided by eval_duration in seconds",
+            "retrieval_precision": (
+                "expected source files intersected with retrieved source files "
+                "divided by expected source files"
+            ),
+        },
+    }
+    aggregate_report = aggregate(results)
+    aggregate_report["paired_comparison"] = paired_comparison(results)
+    return BenchmarkRun("1.0", run_id, config, results, aggregate_report)
+
+
+def save_run(run: BenchmarkRun, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = asdict(run)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def load_run(path: Path) -> BenchmarkRun:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        results = [InferenceResult(**item) for item in payload["results"]]
+        return BenchmarkRun(
+            schema_version=str(payload["schema_version"]),
+            run_id=str(payload["run_id"]),
+            configuration=dict(payload["configuration"]),
+            results=results,
+            aggregate=dict(payload["aggregate"]),
+        )
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        raise ValueError(f"Malformed Phase 4 benchmark result: {path}") from exc
+
+
+def print_report(run: BenchmarkRun) -> None:
+    print(f"Phase 4 benchmark run: {run.run_id}")
+    for mode, metrics in run.aggregate.items():
+        print(f"\n{mode}")
+        for key, value in metrics.items():
+            print(f"  {key}: {value}")
+    failed = [r for r in run.results if not r.success]
+    if failed:
+        print(f"\nFailed cases: {len(failed)}")
+        for result in failed:
+            print(f"  {result.execution_mode}/{result.benchmark_case}: {result.error}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the Phase 4 Raw Ollama vs Codemaster RAG benchmark.")
+    parser.add_argument("--model", default=os.getenv("OLLAMA_MODEL", "qwen2.5-coder:1.5b"))
+    parser.add_argument("--ollama-url", default=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"))
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--top-k", type=int, default=3)
+    parser.add_argument("--alpha", type=float, default=0.5)
+    parser.add_argument("--min-score", type=float, default=0.0)
+    parser.add_argument("--cases", type=Path)
+    parser.add_argument("--output", type=Path, default=Path(".codemaster/benchmarks/phase4-latest.json"))
+    args = parser.parse_args(argv)
+    if args.top_k < 1 or not 0 <= args.alpha <= 1 or not 0 <= args.min_score <= 1:
+        parser.error("top-k must be >= 1; alpha and min-score must be between 0 and 1")
+    cases = load_cases(args.cases)
+    run = execute(cases, args.model, args.ollama_url, args.timeout, args.top_k, args.alpha, args.min_score)
+    save_run(run, args.output)
+    print_report(run)
+    return 0 if all(r.success for r in run.results) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/phase4_benchmark.py
+++ b/backend/phase4_benchmark.py
@@ -13,6 +13,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
+from urllib.parse import urlsplit, urlunsplit
 
 
 @dataclass(frozen=True)
@@ -89,13 +90,20 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def safe_ollama_url(value: str) -> str:
+    parsed = urlsplit(value)
+    host = parsed.hostname or "localhost"
+    port = f":{parsed.port}" if parsed.port else ""
+    return urlunsplit((parsed.scheme or "http", f"{host}{port}", parsed.path, "", ""))
+
+
 def safe_environment() -> dict[str, Any]:
     return {
         "python": platform.python_version(),
         "platform": platform.platform(),
         "system": platform.system(),
         "machine": platform.machine(),
-        "ollama_base_url": os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+        "ollama_base_url": safe_ollama_url(os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")),
     }
 
 
@@ -194,6 +202,8 @@ def _post_json_stream(
                 if not raw_line.strip():
                     continue
                 item = json.loads(raw_line.decode("utf-8"))
+                if item.get("error"):
+                    raise RuntimeError(f"Ollama returned an error: {item['error']}")
                 chunk = str(item.get("response", ""))
                 if chunk and first_token_time is None:
                     first_token_time = time.perf_counter()
@@ -376,7 +386,7 @@ def execute(
         results.append(rag)
     config = {
         "model": model,
-        "ollama_base_url": base_url,
+        "ollama_base_url": safe_ollama_url(base_url),
         "timeout_seconds": timeout,
         "top_k": top_k,
         "alpha": alpha,

--- a/backend/phase4_benchmark.py
+++ b/backend/phase4_benchmark.py
@@ -108,11 +108,12 @@ def safe_environment() -> dict[str, Any]:
 
 
 def retrieval_precision(expected: Sequence[str], retrieved: Sequence[str]) -> float:
+    """Return the fraction of retrieved source entries that are relevant."""
     expected_set = {str(x) for x in expected if str(x)}
-    retrieved_set = {str(x) for x in retrieved if str(x)}
-    if not expected_set:
+    retrieved_values = [str(x) for x in retrieved if str(x)]
+    if not retrieved_values:
         return 0.0
-    return len(expected_set & retrieved_set) / len(expected_set)
+    return sum(source in expected_set for source in retrieved_values) / len(retrieved_values)
 
 
 def _number(value: Any) -> int | float | None:
@@ -396,8 +397,7 @@ def execute(
             "ttft": "wall-clock elapsed from HTTP request start until first non-empty streamed response chunk",
             "tps": "Ollama eval_count divided by eval_duration in seconds",
             "retrieval_precision": (
-                "expected source files intersected with retrieved source files "
-                "divided by expected source files"
+                "relevant retrieved source entries divided by retrieved source entries"
             ),
         },
     }

--- a/backend/tests/test_phase4_benchmark.py
+++ b/backend/tests/test_phase4_benchmark.py
@@ -1,0 +1,89 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from phase4_benchmark import (
+    BenchmarkCase,
+    BenchmarkRun,
+    InferenceResult,
+    aggregate,
+    calculate_tps,
+    load_cases,
+    load_run,
+    paired_comparison,
+    retrieval_precision,
+    run_ollama,
+    save_run,
+)
+
+
+class Phase4MetricTests(unittest.TestCase):
+    def test_tps_uses_eval_metadata(self):
+        self.assertEqual(calculate_tps(100, 2_000_000_000), 50.0)
+
+    def test_tps_rejects_invalid_data(self):
+        self.assertIsNone(calculate_tps(0, 0))
+        self.assertIsNone(calculate_tps("100", 2_000_000_000))
+
+    def test_retrieval_precision_is_source_intersection(self):
+        self.assertEqual(retrieval_precision(["a.py", "b.py"], ["b.py", "c.py"]), 0.5)
+        self.assertEqual(retrieval_precision([], ["a.py"]), 0.0)
+
+    def test_aggregate_handles_missing_metrics(self):
+        rows = [
+            InferenceResult("a", "raw_ollama", "m", "a", "t", True, 10, 20, 30),
+            InferenceResult("b", "raw_ollama", "m", "b", "t", False, None, None, None),
+            InferenceResult("a", "codemaster_rag", "m", "a", "t", True, 20, 10, 40, retrieval_precision=1.0),
+        ]
+        report = aggregate(rows)
+        self.assertEqual(report["raw_ollama"]["cases"], 2)
+        self.assertEqual(report["raw_ollama"]["success_rate"], 0.5)
+        self.assertEqual(report["codemaster_rag"]["average_retrieval_precision"], 1.0)
+
+    def test_paired_comparison(self):
+        rows = [
+            InferenceResult("a", "raw_ollama", "m", "a", "t", True, 10, 20, 30),
+            InferenceResult("a", "codemaster_rag", "m", "a", "t", True, 15, 25, 40, retrieval_precision=1.0),
+        ]
+        comparison = paired_comparison(rows)
+        self.assertEqual(comparison["paired_case_count"], 1)
+        self.assertEqual(comparison["cases"][0]["ttft_delta_ms_rag_minus_baseline"], 5)
+
+    def test_unavailable_ollama_is_controlled_failure(self):
+        case = BenchmarkCase("x", "task", ("a.py",))
+        result = run_ollama("task", "model", "http://127.0.0.1:1", 0.1, case, "raw_ollama", [])
+        self.assertFalse(result.success)
+        self.assertIsNone(result.ttft_ms)
+        self.assertIsNotNone(result.error)
+
+    def test_result_persistence_round_trip_and_malformed_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "run.json"
+            run = BenchmarkRun(
+                "1.0",
+                "id",
+                {"model": "m"},
+                [InferenceResult("a", "raw_ollama", "m", "a", "t", True, 1, 2, 3)],
+                {"raw_ollama": {"cases": 1}},
+            )
+            save_run(run, path)
+            loaded = load_run(path)
+            self.assertEqual(loaded.run_id, "id")
+            path.write_text("{bad", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                load_run(path)
+
+    def test_case_file_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "cases.json"
+            path.write_text(
+                json.dumps([{"case_id": "x", "task": "task", "expected_sources": ["a.py"]}]),
+                encoding="utf-8",
+            )
+            cases = load_cases(path)
+            self.assertEqual(cases, [BenchmarkCase("x", "task", ("a.py",))])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_phase4_benchmark.py
+++ b/backend/tests/test_phase4_benchmark.py
@@ -26,8 +26,22 @@ class Phase4MetricTests(unittest.TestCase):
         self.assertIsNone(calculate_tps(0, 0))
         self.assertIsNone(calculate_tps("100", 2_000_000_000))
 
-    def test_retrieval_precision_is_source_intersection(self):
-        self.assertEqual(retrieval_precision(["a.py", "b.py"], ["b.py", "c.py"]), 0.5)
+    def test_retrieval_precision_counts_relevant_retrieved_sources(self):
+        self.assertAlmostEqual(
+            retrieval_precision(["a.py"], ["a.py", "b.py", "c.py"]),
+            1 / 3,
+        )
+
+    def test_retrieval_precision_perfect(self):
+        self.assertEqual(retrieval_precision(["a.py", "b.py"], ["a.py", "b.py"]), 1.0)
+
+    def test_retrieval_precision_zero_relevant(self):
+        self.assertEqual(retrieval_precision(["a.py"], ["b.py", "c.py"]), 0.0)
+
+    def test_retrieval_precision_empty_retrieval(self):
+        self.assertEqual(retrieval_precision(["a.py"], []), 0.0)
+
+    def test_retrieval_precision_empty_expected_sources(self):
         self.assertEqual(retrieval_precision([], ["a.py"]), 0.0)
 
     def test_aggregate_handles_missing_metrics(self):

--- a/benchmarks/phase4_cases.json
+++ b/benchmarks/phase4_cases.json
@@ -1,0 +1,22 @@
+[
+  {
+    "case_id": "retrieval-hybrid-ranking",
+    "task": "Explain how Codemaster-AI combines dense vector retrieval and BM25, including how the hybrid score is formed.",
+    "expected_sources": ["backend/app/services/hybrid_retriever.py"]
+  },
+  {
+    "case_id": "vector-index-failure-state",
+    "task": "Explain how the repository vector engine handles indexing failures and what state it exposes after a failed build.",
+    "expected_sources": ["backend/app/utils/vector_engine.py"]
+  },
+  {
+    "case_id": "generation-context-handoff",
+    "task": "Explain how the generation route retrieves repository context and passes it into the model prompt, including the retrieval failure behavior.",
+    "expected_sources": ["backend/app/routes/generation.py"]
+  },
+  {
+    "case_id": "ollama-provider-runtime",
+    "task": "Explain how the Ollama provider calls the local API, selects its model, and handles provider failures.",
+    "expected_sources": ["backend/app/llm/providers/ollama.py"]
+  }
+]

--- a/run_phase4_benchmark.py
+++ b/run_phase4_benchmark.py
@@ -1,0 +1,7 @@
+"""CLI entry point for the Phase 4 local benchmark."""
+
+from backend.phase4_benchmark import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Phase 4 — Local Benchmarking & Metrics

## Purpose

This PR proposes merging:

`phase-4-local-benchmarking-metrics`

into:

`main`

This is a Phase 4 validation PR intended to verify that the completed Phase 4 implementation integrates cleanly with the current `main` branch and that the repository's CI/CD, build, test, security, and deployment automation remains healthy.

## Phase 4 Scope

Phase 4 introduces the local benchmarking and metrics infrastructure for comparing:

**Raw Ollama baseline**
vs.
**Codemaster RAG**

using:

- TTFT
- TPS
- Context Retrieval Precision
- Per-case benchmark results
- Aggregate metrics
- Raw-vs-RAG paired comparison

## Implemented

- Reusable Phase 4 benchmark harness
- Four repository-aware benchmark cases
- Raw Ollama baseline execution path
- Codemaster RAG execution path using the existing Phase 3 hybrid retriever
- Stream-based TTFT measurement
- Ollama metadata-based TPS calculation
- Context Retrieval Precision
- Precision regression tests
- Benchmark result persistence/reload
- Atomic benchmark-result persistence
- Aggregation and median/average metrics
- Raw-vs-RAG paired comparison
- Controlled Ollama/retrieval/metric failure handling
- Phase 4 benchmark documentation
- Benchmark-result directory protection in `.gitignore`

## Important Precision Correction

The final implementation defines Context Retrieval Precision as:

`relevant retrieved sources / all retrieved sources`

Equivalent to:

`len(expected ∩ retrieved) / len(retrieved)`

Regression coverage includes:

- partial precision → `1/3`
- perfect precision → `1.0`
- zero precision → `0.0`
- empty retrieval
- empty expected-source set

This prevents the previously identified recall-like calculation from returning an incorrect precision value.

## Verification Performed

The Phase 4 branch has undergone a dedicated read-only final audit.

The audit found no unresolved Phase 4 implementation correctness issue.

Verified areas include:

- benchmark harness
- repository-aware cases
- Raw Ollama path
- existing Phase 3 RAG path
- TTFT implementation
- TPS implementation
- retrieval precision
- precision regression tests
- persistence
- aggregation
- paired comparison
- failure handling
- documentation
- branch isolation
- main protection

## CI/CD Integration Verification

This PR is intentionally being opened so GitHub can independently evaluate the actual merge candidate through the repository's configured automation.

Please verify all applicable:

- GitHub Actions workflows
- unit/integration tests
- build checks
- lint/static analysis
- dependency validation
- security checks
- CodeQL/security automation
- package/build workflows
- deployment/release-related checks, if triggered by this PR

Do not treat "Able to merge" alone as evidence that CI/CD is healthy.

## Live Benchmark Status

A live Ollama benchmark has **not** been represented as completed.

No fabricated TTFT, TPS, retrieval-precision, or Raw-vs-RAG performance numbers are included in this PR.

The live benchmark remains environment-dependent and should only be reported after genuine Ollama execution.

## Merge Safety

This PR is based on the Phase 4 branch:

`phase-4-local-benchmarking-metrics`

The intended target is:

`main`

No Phase 4 changes should be merged unless the required automated checks pass.

## Review Request

Please use this PR to verify whether Phase 4 can safely integrate with `main`.

In particular, confirm:

1. All required CI checks pass.
2. Existing repository tests remain healthy.
3. Build/package validation passes.
4. Static/security checks pass.
5. No Phase 4 change introduces a regression.
6. Existing automation remains compatible with the Phase 4 branch.
7. No deployment/release workflow is negatively affected.

### Decision

If all required checks pass:

**Phase 4 is ready for merge into `main`.**

If any check fails:

**Do not merge. Investigate the failure first.**